### PR TITLE
[exception] make mpp::throw_ex safe

### DIFF
--- a/mozart++/core/any.hpp
+++ b/mozart++/core/any.hpp
@@ -190,7 +190,7 @@ private:
     inline stor_base *get_handler() {
         switch (m_data.status) {
             case stor_status::null:
-                throw_ex<runtime_error>("Access null any object.");
+                throw_ex<mpp::runtime_error>("Access null any object.");
             case stor_status::data:
                 return reinterpret_cast<stor_base *>(m_data.impl.data);
             case stor_status::ptr:
@@ -202,7 +202,7 @@ private:
     inline const stor_base *get_handler() const {
         switch (m_data.status) {
             case stor_status::null:
-                throw_ex<runtime_error>("Access null any object.");
+                throw_ex<mpp::runtime_error>("Access null any object.");
             case stor_status::data:
                 return reinterpret_cast<const stor_base *>(m_data.impl.data);
             case stor_status::ptr:
@@ -317,7 +317,7 @@ public:
     inline T &get() {
         stor_base *ptr = get_handler();
         if (ptr->type() != typeid(T))
-            throw_ex<runtime_error>("Access wrong type of any.");
+            throw_ex<mpp::runtime_error>("Access wrong type of any.");
         return static_cast<stor_impl<T> *>(ptr)->data;
     }
 
@@ -326,7 +326,7 @@ public:
     inline const T &get() const {
         const stor_base *ptr = get_handler();
         if (ptr->type() != typeid(T))
-            throw_ex<runtime_error>("Access wrong type of any.");
+            throw_ex<mpp::runtime_error>("Access wrong type of any.");
         return static_cast<const stor_impl<T> *>(ptr)->data;
     }
 };

--- a/mozart++/core/exception.hpp
+++ b/mozart++/core/exception.hpp
@@ -13,13 +13,18 @@
 #include <string>
 
 namespace mpp {
-    class runtime_error final : public std::exception {
+    /**
+     * This class represents unexpected runtime exceptions.
+     * User-defined exceptions can derive from this base class.
+     */
+    class runtime_error : public std::exception {
         std::string mWhat = "Runtime Error";
 
     public:
         runtime_error() = default;
 
-        explicit runtime_error(const std::string &str) noexcept : mWhat("Runtime Error: " + str) {}
+        explicit runtime_error(const std::string &str) noexcept
+            : mWhat("Runtime Error: " + str) {}
 
         runtime_error(const runtime_error &) = default;
 
@@ -38,7 +43,10 @@ namespace mpp {
 
     template <typename T, typename... ArgsT>
     void throw_ex(ArgsT &&... args) {
-        T exception(std::forward<ArgsT>(args)...);
+        static_assert(std::is_base_of<std::exception, T>::value,
+            "Only std::exception and its derived classes can be thrown");
+
+        T exception{std::forward<ArgsT>(args)...};
         MOZART_LOGCR(exception.what())
 #ifdef MOZART_NOEXCEPT
         std::terminate();


### PR DESCRIPTION
Major changes:
* Ensure only exceptions can be thrown by `mpp::throw_ex`
* Use universal initialization syntax to create exception instance.