### PR TITLE
Optional features enhancement

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -27,7 +27,6 @@ Mozart++ 有两个 `namespace`, `mpp` 和 `mpp_impl`.
   * `mpp::any`: 效率极高的 `std::any`
   * `mpp::allocator_type`: 通用内存分配器具
 * C
-  * `mpp::curry()`: 将普通的 C++ 函数转变成「柯里化」的函数
   * `mpp::codecvt`: 宽字符串和普通字符串的互相转换器
 * E
   * `mpp::event_emitter`: 像 NodeJS 那样的并且无侵入性的 EventEmitter (两个实现):

--- a/mozart++/core/optional.hpp
+++ b/mozart++/core/optional.hpp
@@ -250,7 +250,7 @@ namespace mpp {
             return static_cast<bool>(_memory[0]);
         }
 
-        operator bool() {
+        /*implicit*/ operator bool() {
             return has_value();
         }
     };

--- a/mozart++/core/type_traits.hpp
+++ b/mozart++/core/type_traits.hpp
@@ -10,6 +10,39 @@
 
 #include <type_traits>
 
+#define mpp_in_place_type_t(T)  mpp_impl::in_place_t(&)(mpp_impl::in_place_type_tag<T>)
+#define mpp_in_place_index_t(T)  mpp_impl::in_place_t(&)(mpp_impl::in_place_index_tag<I>)
+
+namespace mpp_impl {
+    template <typename T>
+    struct in_place_type_tag {};
+
+    template <std::size_t I>
+    struct in_place_index_tag {};
+
+    struct in_place_t {};
+
+    template <typename T>
+    inline in_place_t in_place(in_place_type_tag<T> = in_place_type_tag<T>()) {
+        return in_place_t{};
+    }
+
+    template <std::size_t I>
+    inline in_place_t in_place(in_place_index_tag<I> = in_place_index_tag<I>()) {
+        return in_place_t{};
+    }
+
+    template <typename T>
+    inline in_place_t in_place_type(in_place_type_tag<T> = in_place_type_tag<T>()) {
+        return in_place_t{};
+    }
+
+    template <std::size_t I>
+    inline in_place_t in_place_index(in_place_index_tag<I> = in_place_index_tag<I>()) {
+        return in_place_t{};
+    }
+}
+
 namespace mpp {
     template <typename ...>
     using void_t = void;

--- a/tests/test-optional.cpp
+++ b/tests/test-optional.cpp
@@ -12,7 +12,7 @@
 #include <cstdio>
 
 void sayHi(mpp::optional<std::string> name) {
-    if (name.has_value()) {
+    if (name) {
         printf("hi: %s\n", name.get().c_str());
     } else {
         printf("you didn't tell me who you are) QwQ\n");
@@ -30,11 +30,13 @@ int sum(const mpp::optional<std::vector<int>> &nums) {
 }
 
 int main(int argc, const char **argv) {
-    sayHi(mpp::optional<std::string>::none());
-    sayHi(mpp::optional<std::string>::from("imkiva"));
+    sayHi(mpp::none);
+    sayHi(mpp::optional<std::string>("hello"));
+    sayHi(mpp::some<std::string>("world"));
+    sayHi(std::string("imkiva"));
 
     std::vector<int> v{1, 2, 3, 4};
-    printf("sum1 = %d\n", sum(mpp::optional<decltype(v)>::from(v)));
-    printf("sum2 = %d\n", sum(mpp::optional<decltype(v)>::none()));
-    printf("sum3 = %d\n", sum(mpp::optional<decltype(v)>::emplace(1, 2, 3, 4, 5)));
+    printf("sum1 = %d\n", sum(mpp::some<decltype(v)>(v)));
+    printf("sum2 = %d\n", sum(mpp::none));
+    printf("sum3 = %d\n", sum(mpp::some<decltype(v)>(1, 2, 3, 4, 5)));
 }


### PR DESCRIPTION
* Added `mpp::none` to construct an empty optional, to avoid typing useless typename.

* Added `mpp::some` to emplace optional object, to avoid calling ctors explicitly, for example, `mpp::some<std::string>("hello world")` and `mpp::some<std::vector<int>>(1, 2, 3, 4, 5)`

* Mark optional ctor from type T **implicit**, for example, `mpp::optional<std::string>("good job")`.

* Added `operator bool()` for convenience.